### PR TITLE
Remove deprecated Homebrew casks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,4 @@
 # Taps
-tap 'homebrew/cask-fonts'
-tap 'homebrew/cask-versions'
 tap 'homebrew/bundle'
 
 # Binaries
@@ -29,6 +27,7 @@ cask 'docker'
 cask 'duckduckgo'
 cask 'firefox'
 cask 'font-meslo-for-powerlevel10k'
+cask 'font-roboto'
 cask 'gimp'
 cask 'github'
 cask 'google-chrome'


### PR DESCRIPTION
```shell
Tapping homebrew/cask-fonts
Error: homebrew/cask-fonts was deprecated. This tap is now empty and all its contents were either deleted or migrated.
Tapping homebrew/cask-fonts has failed!
```
```shell
Tapping homebrew/cask-versions
Error: homebrew/cask-versions was deprecated. This tap is now empty and all its contents were either deleted or migrated.
Tapping homebrew/cask-versions has failed!
```