### PR TITLE
Replace `tldr` with `tlrc`, as the former is now deprecated

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -19,7 +19,7 @@ brew 'rbenv'
 brew 'ruby-build'
 brew 'speedtest-cli'
 brew 'thefuck'
-brew 'tldr'
+brew 'tlrc'
 brew "topgrade"
 brew 'tree'
 brew 'wget'


### PR DESCRIPTION
Fixes #50