### PR TITLE
Fix typo in the system update command (`softwarepudate` -> `softwareupdate`)

### DIFF
--- a/aliases.zsh
+++ b/aliases.zsh
@@ -167,7 +167,7 @@ fi
 # Keeps all apps and packages up to date.
 # Syntax: `update [all]`
 function update() {
-    if command -v softwarepudate &> /dev/null; then
+    if command -v softwareupdate &> /dev/null; then
         echo 'Checking for system updates...'
         softwareupdate -l -i -a
     fi


### PR DESCRIPTION
Fixes #53 