### PR TITLE
Fix the "bad assignment" error when starting new terminal session

### DIFF
--- a/aliases.zsh
+++ b/aliases.zsh
@@ -55,7 +55,7 @@ function docker-cleanup-all() {
 #
 alias yolo='git commit -m "$(curl -s https://whatthecommit.com/index.txt)"'
 alias gcfu='git branch --no-color --sort=-committerdate --format="%(refname:short)" | fzf --header "git checkout" | xargs git checkout'
-alias gcpa = 'git format-patch --progress -1'
+alias gcpa='git format-patch --progress -1'
 
 # Displays drives and space in human readable format
 alias dfh='df -h'


### PR DESCRIPTION
# Error

```
aliases.zsh:58: bad assignment
gcpa='git cherry-pick --abort'
```

# Related PR
https://github.com/kniziol/dotfiles/pull/75