### PR TITLE
Fix the `docker was renamed to docker-desktop` warning when installing Brew packages. Rename the `docker` Brew package to `docker-desktop`.

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -27,7 +27,7 @@ brew 'wget'
 
 # Apps
 cask 'discord'
-cask 'docker'
+cask 'docker-desktop'
 cask 'duckduckgo'
 cask 'elmedia-player'
 cask 'exifcleaner'


### PR DESCRIPTION
Closes #77