### PR TITLE
Rename alias for the Git command that generates a patch from a specified commit (`gcpa` -> `gfpa`)

### DIFF
--- a/aliases.zsh
+++ b/aliases.zsh
@@ -55,7 +55,7 @@ function docker-cleanup-all() {
 #
 alias yolo='git commit -m "$(curl -s https://whatthecommit.com/index.txt)"'
 alias gcfu='git branch --no-color --sort=-committerdate --format="%(refname:short)" | fzf --header "git checkout" | xargs git checkout'
-alias gcpa='git format-patch --progress -1'
+alias gfpa='git format-patch --progress -1'
 
 # Displays drives and space in human readable format
 alias dfh='df -h'


### PR DESCRIPTION
The `gcpa` alias has been already used for the `git cherry-pick --abort` command