### PR TITLE
Use the `nvim` instead of `vim` as the default Git editor in global Git configuration

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -3,7 +3,7 @@
 [core]
 	excludesfile = ~/.gitignore_global
 	autocrlf = input
-	editor = vim
+	editor = nvim
 	# editor = open -a 'Sublime Text' --wait
 [filter "lfs"]
 	required = true


### PR DESCRIPTION
Closes #97